### PR TITLE
Remove look-alike character from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,7 +263,7 @@ Send output to file:
     print(ps.hypothesis())
 
 -------------
-Сompatibility
+Compatibility
 -------------
 
 Parent classes are still available:


### PR DESCRIPTION
The cyrillic es character was used instead of an actual C which caused a utf error when installing via `pip3` (because it's parsed in setups.py)