### PR TITLE
Fix build against setuptools 65

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ import sys
 from shutil import copy, copytree, ignore_patterns
 from glob import glob
 
-from distutils import log
-from distutils.command.build import build as _build
 try:
     from setuptools import setup, Extension
     from setuptools.command.install import install as _install
@@ -15,6 +13,9 @@ except ImportError:
     from distutils.extension import Extension
     from distutils.command.install import install as _install
     from distutils.command.bdist_egg import bdist_egg as _bdist_egg
+
+from distutils import log
+from distutils.command.build import build as _build
 
 if sys.platform.startswith('win'):
     from distutils.command.bdist_msi import bdist_msi as _bdist_msi


### PR DESCRIPTION
The newer setuptools warns:

/usr/lib/python3/dist-packages/_distutils_hack/__init__.py:18: UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.

So we have to import setuptools before any distutils import.